### PR TITLE
Update broken AWS credentials links from comments

### DIFF
--- a/ConsoleSamples/AmazonGlacierSample/AmazonGlacierSample/Program.cs
+++ b/ConsoleSamples/AmazonGlacierSample/AmazonGlacierSample/Program.cs
@@ -30,7 +30,7 @@ namespace AmazonGlacierSample
     class Program
     {
         // Change the AWSProfileName to the profile you want to use in the App.config file.
-        // See http://aws.amazon.com/credentials  for more details.
+        // See http://docs.aws.amazon.com/AWSSdkDocsNET/latest/DeveloperGuide/net-dg-config-creds.html for more details.
         // You must also sign up for an Amazon Glacier account for this to work
         // See http://aws.amazon.com/glacier/ for details on creating an Amazon Glacier account
         // Change the vaultName and fileName fields to values that match your vaultName and fileName

--- a/ConsoleSamples/AmazonS3Sample/AmazonS3Sample/S3Sample.cs
+++ b/ConsoleSamples/AmazonS3Sample/AmazonS3Sample/S3Sample.cs
@@ -29,7 +29,7 @@ namespace GettingStartedGuide
     class S3Sample
     {
         // Change the AWSProfileName to the profile you want to use in the App.config file.
-        // See http://aws.amazon.com/credentials  for more details.
+        // See http://docs.aws.amazon.com/AWSSdkDocsNET/latest/DeveloperGuide/net-dg-config-creds.html for more details.
         // You must also sign up for an Amazon S3 account for this to work
         // See http://aws.amazon.com/s3/ for details on creating an Amazon S3 account
         // Change the bucketName and keyName fields to values that match your bucketname and keyname

--- a/ConsoleSamples/AmazonSesSample/AmazonSesSample/Program.cs
+++ b/ConsoleSamples/AmazonSesSample/AmazonSesSample/Program.cs
@@ -27,7 +27,7 @@ namespace AmazonSesSample
     class Program
     {
         // Change the AWSProfileName to the profile you want to use in the App.config file.
-        // See http://aws.amazon.com/credentials  for more details.
+        // See http://docs.aws.amazon.com/AWSSdkDocsNET/latest/DeveloperGuide/net-dg-config-creds.html for more details.
         // You must also sign up for an Amazon SES account for this to work
         // See http://aws.amazon.com/ses/ for details on creating an Amazon SES account
         // This sample send a mail using SES.

--- a/ConsoleSamples/S3FileSystem_Sample/S3FileSystem_Sample/Program.cs
+++ b/ConsoleSamples/S3FileSystem_Sample/S3FileSystem_Sample/Program.cs
@@ -30,7 +30,7 @@ namespace S3FileSystem_Sample
     class Program
     {
         // Change the AWSProfileName to the profile you want to use in the App.config file.
-        // See http://aws.amazon.com/credentials  for more details.
+        // See http://docs.aws.amazon.com/AWSSdkDocsNET/latest/DeveloperGuide/net-dg-config-creds.html for more details.
         // You must also sign up for an Amazon S3 account for this to work
         // See http://aws.amazon.com/s3/ for details on creating an Amazon S3 account
         // Change the bucketName field to a unique name that will be created and used for the sample.


### PR DESCRIPTION
This commit addresses the #5 issue. The existing link in the comments (http://aws.amazon.com/credentials) that is supposed to provide details on configuring the AWS credentials is returning a 404. I have replaced it with the developer guide URL that is specified in the _README.md_ files of the sample projects.
