### PR TITLE
Removed an outdated reference to a guide that no longer exists.

### DIFF
--- a/ConsoleSamples/AmazonSQS_Sample/README.md
+++ b/ConsoleSamples/AmazonSQS_Sample/README.md
@@ -11,5 +11,3 @@ The basic steps for running the Amazon SQS sample are:
 3. Configure your AWS credentials. View the [developer guide](http://docs.aws.amazon.com/AWSSdkDocsNET/latest/DeveloperGuide/net-dg-config-creds.html) for configuring AWS credentials:
 4. Save the file.
 5. Run the sample in Debug mode by typing F5.
-
-See the [Amazon SQS Getting Started Guide](http://docs.amazonwebservices.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/) for step-by-step instructions on running this sample.


### PR DESCRIPTION
The _Amazon SQS Getting Started Guide_ has been retired. The most current information is in the _Amazon SQS Developer Guide_: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html